### PR TITLE
Fixed names preventing skins to be loaded

### DIFF
--- a/ClassicalSharp/Network/NetworkProcessor.CPE.cs
+++ b/ClassicalSharp/Network/NetworkProcessor.CPE.cs
@@ -154,6 +154,9 @@ namespace ClassicalSharp {
 			string listName = reader.ReadAsciiString();
 			string groupName = reader.ReadAsciiString();
 			byte groupRank = reader.ReadUInt8();
+
+            if( playerName.EndsWith( "+" ) )
+                playerName = playerName.TrimEnd( '+' );
 			
 			if( nameId >= 0 && nameId <= 255 ) {
 				CpeListInfo oldInfo = game.CpePlayersList[nameId];
@@ -173,7 +176,13 @@ namespace ClassicalSharp {
 			byte entityId = reader.ReadUInt8();
 			string displayName = reader.ReadAsciiString();
 			string skinName = reader.ReadAsciiString();
-			AddEntity( entityId, displayName, skinName, false );
+
+            if( displayName.EndsWith( "+" ) )
+                displayName = displayName.TrimEnd( '+' );
+            if( skinName.EndsWith( "+" ) )
+                skinName = skinName.TrimEnd( '+' );
+
+            AddEntity( entityId, displayName, skinName, false );
 		}
 		
 		void HandleCpeExtRemovePlayerName() {
@@ -305,7 +314,13 @@ namespace ClassicalSharp {
 			byte entityId = reader.ReadUInt8();
 			string displayName = reader.ReadAsciiString();
 			string skinName = reader.ReadAsciiString();
-			AddEntity( entityId, displayName, skinName, true );
+
+            if( displayName.EndsWith( "+" ) )
+                displayName = displayName.TrimEnd( '+' );
+            if( skinName.EndsWith( "+" ) )
+                skinName = skinName.TrimEnd( '+' );
+
+            AddEntity( entityId, displayName, skinName, true );
 		}
 		
 		void HandleCpeDefineBlock() {

--- a/ClassicalSharp/Network/NetworkProcessor.cs
+++ b/ClassicalSharp/Network/NetworkProcessor.cs
@@ -334,6 +334,10 @@ namespace ClassicalSharp {
 		void HandleAddEntity() {
 			byte entityId = reader.ReadUInt8();
 			string name = reader.ReadAsciiString();
+
+            if( name.EndsWith( "+" ) )
+                name = name.TrimEnd( '+' );
+
 			AddEntity( entityId, name, name, true );
 		}
 		


### PR DESCRIPTION
Entity name tags and player names in lists are now checked to see if
they contain a "+" at the end, and if they do, that "+" is removed.