### PR TITLE
Made inventory switching re-bindable and fixed CRTL selecting in inventory screen closing inventory screen.

### DIFF
--- a/ClassicalSharp/2D/Screens/Inventory/InventoryScreen.Input.cs
+++ b/ClassicalSharp/2D/Screens/Inventory/InventoryScreen.Input.cs
@@ -48,7 +48,7 @@ namespace ClassicalSharp.Gui.Screens {
 					return true;
 				}
 				
-				bool hotbar = game.IsKeyDown(Key.AltLeft) || game.IsKeyDown(Key.AltRight);
+				bool hotbar = game.Input.ControlDown;
 				if (!hotbar)
 					game.Gui.SetNewScreen(null);
 			}

--- a/ClassicalSharp/2D/Screens/Menu/KeyBindingsScreens.cs
+++ b/ClassicalSharp/2D/Screens/Menu/KeyBindingsScreens.cs
@@ -120,12 +120,12 @@ namespace ClassicalSharp.Gui.Screens {
 		
 		public override void Init() {
 			base.Init();
-			left = new KeyBind[3];
-			left[0] = KeyBind.ExtInput; left[1] = KeyBind.HideFps; left[2] = KeyBind.HideGui;
+			left = new KeyBind[4];
+			left[0] = KeyBind.ExtInput; left[1] = KeyBind.HideFps; left[2] = KeyBind.HideGui; left[3] = KeyBind.HotbarSwitching;
 			right = new KeyBind[4];
 			right[0] = KeyBind.Screenshot; right[1] = KeyBind.Fullscreen; right[2] = KeyBind.AxisLines; right[3] = KeyBind.Autorotate;
-			leftDesc = new string[] { "Show ext input", "Hide FPS", "Hide gui" };
-			rightDesc = new string[] { "Screenshot", "Fullscreen", "Show axis lines", "Toggle auto-rotate" };
+			leftDesc = new string[] { "Show ext input", "Hide FPS", "Hide gui", "Hotbar switching" };
+			rightDesc = new string[] { "Screenshot", "Fullscreen", "Show axis lines", "Toggle auto-rotate", };
 			
 			title = "Other controls";
 			leftPage = (g, w) => g.Gui.SetNewScreen(new HacksKeyBindingsScreen(g));

--- a/ClassicalSharp/2D/Widgets/HotbarWidget.cs
+++ b/ClassicalSharp/2D/Widgets/HotbarWidget.cs
@@ -120,7 +120,7 @@ namespace ClassicalSharp.Gui.Widgets {
 			// a) user presses alt then number
 			// b) user presses alt
 			// thus we only do case b) if case a) did not happen
-			if (!(key == Key.AltLeft || key == Key.AltRight)) return false;			
+			if (!(key == game.Input.Keys[KeyBind.HotbarSwitching])) return false;			
 			if (altHandled) { altHandled = false; return true; } // handled already
 			
 			// Alternate between first and second row

--- a/ClassicalSharp/Game/KeyMap.cs
+++ b/ClassicalSharp/Game/KeyMap.cs
@@ -10,8 +10,8 @@ namespace ClassicalSharp {
 		Forward, Back, Left, Right, Jump, Respawn, SetSpawn, Chat,
 		Inventory, ToggleFog, SendChat, PauseOrExit, PlayerList,
 		Speed, NoClip, Fly, FlyUp, FlyDown, ExtInput, HideFps,
-		Screenshot, Fullscreen, ThirdPerson, HideGui, AxisLines,
-		ZoomScrolling, HalfSpeed, MouseLeft, MouseMiddle, MouseRight, Autorotate,
+		HotbarSwitching, Screenshot, Fullscreen, ThirdPerson, HideGui, AxisLines,
+		ZoomScrolling, HalfSpeed, MouseLeft, MouseMiddle, MouseRight, Autorotate
 #pragma warning restore 1591
 	}
 	
@@ -34,17 +34,16 @@ namespace ClassicalSharp {
 		public KeyMap() {
 			// We can't use enum array initaliser because this causes problems when building with mono
 			// and running on default .NET (https://bugzilla.xamarin.com/show_bug.cgi?id=572)
-			keys = new Key[31];
+			keys = new Key[32];
 			keys[0] = Key.W; keys[1] = Key.S; keys[2] = Key.A; keys[3] = Key.D;
 			keys[4] = Key.Space; keys[5] = Key.R; keys[6] = Key.Enter; keys[7] = Key.T;
 			keys[8] = Key.B; keys[9] = Key.F; keys[10] = Key.Enter;
 			keys[11] = Key.Escape; keys[12] = Key.Tab; keys[13] = Key.ShiftLeft;
 			keys[14] = Key.X; keys[15] = Key.Z; keys[16] = Key.Q;
 			keys[17] = Key.E; keys[18] = Key.AltLeft; keys[19] = Key.F3;
-			keys[20] = Key.F12; keys[21] = Key.F11; keys[22] = Key.F5;
-			keys[23] = Key.F1; keys[24] = Key.F7; keys[25] = Key.C;
-			keys[26] = Key.ControlLeft;
-			keys[27] = Key.Unknown; keys[28] = Key.Unknown; keys[29] = Key.Unknown;  keys[30] = Key.F6;
+			keys[20] = Key.AltLeft; keys[21] = Key.F12; keys[22] = Key.F11; keys[23] = Key.F5;
+			keys[24] = Key.F1; keys[25] = Key.F7; keys[26] = Key.C; keys[27] = Key.ControlLeft;
+			keys[28] = Key.Unknown; keys[29] = Key.Unknown; keys[30] = Key.Unknown;  keys[31] = Key.F6;
 			
 			defaultKeys = new Key[keys.Length];
 			for (int i = 0; i < defaultKeys.Length; i++)


### PR DESCRIPTION
Inventory switching(I.E. Pressing ALT in-game showing a second inventory) is now re-bindable.

Pressing the CRTL keys should've allowed the user to select a block without the inventory screen closing, but this was not the case. Instead, that functionality was binded to the ALT keys. It has now been re-binded to the CRTL keys.