### PR TITLE
Fix V3041 warnings from PVS-Studio Static Analyzer

### DIFF
--- a/ClassicalSharp/2D/Widgets/TableWidget.cs
+++ b/ClassicalSharp/2D/Widgets/TableWidget.cs
@@ -67,14 +67,14 @@ namespace ClassicalSharp.Gui.Widgets {
 				// We want to always draw the selected block on top of others
 				if (i == SelectedIndex) continue;
 				drawer.DrawBatch(Elements[i], blockSize * 0.7f / 2f,
-				                 x + blockSize / 2, y + blockSize / 2);
+				                 (float)(x + blockSize) / 2, (float)(y + blockSize) / 2);
 			}
 			
 			if (SelectedIndex != -1) {
 				int x, y;
 				GetCoords(SelectedIndex, out x, out y);
 				drawer.DrawBatch(Elements[SelectedIndex], (blockSize + selBlockExpand) * 0.7f / 2,
-				                 x + blockSize / 2, y + blockSize / 2);
+                                 (float)(x + blockSize) / 2, (float)(y + blockSize) / 2);
 			}
 			drawer.EndBatch();
 			

--- a/ClassicalSharp/Network/IServerConnection.cs
+++ b/ClassicalSharp/Network/IServerConnection.cs
@@ -168,8 +168,8 @@ namespace ClassicalSharp {
 		}
 
 		void ResetPlayerPosition() {
-			float x = (game.World.Width  / 2) + 0.5f;
-			float z = (game.World.Length / 2) + 0.5f;
+			float x = ((float)game.World.Width  / 2) + 0.5f;
+			float z = ((float)game.World.Length / 2) + 0.5f;
 			Vector3 spawn = Respawn.FindSpawnPosition(game, x, z, game.LocalPlayer.Size);
 			
 			LocationUpdate update = LocationUpdate.MakePosAndOri(spawn, 0, 0, false);


### PR DESCRIPTION
Hello. I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

**About your warnings:** [V3041](https://www.viva64.com/en/w/V3041/).

### Warnings with High priority:

[V3041](https://www.viva64.com/en/w/V3041/) The expression was implicitly cast from 'int' type to 'float' type. Consider utilizing an explicit type cast to avoid the loss of a fractional part. An example: double A = (double)(X) / Y;. TableWidget.cs 70

[V3041](https://www.viva64.com/en/w/V3041/) The expression was implicitly cast from 'int' type to 'float' type. Consider utilizing an explicit type cast to avoid the loss of a fractional part. An example: double A = (double)(X) / Y;. TableWidget.cs 77

[V3041](https://www.viva64.com/en/w/V3041/) The expression was implicitly cast from 'int' type to 'float' type. Consider utilizing an explicit type cast to avoid the loss of a fractional part. An example: double A = (double)(X) / Y;. IServerConnection.cs 171

[V3041](https://www.viva64.com/en/w/V3041/) The expression was implicitly cast from 'int' type to 'float' type. Consider utilizing an explicit type cast to avoid the loss of a fractional part. An example: double A = (double)(X) / Y;. IServerConnection.cs 172