### PR TITLE
InteropPatcher incompatibilities on platforms that use `mono`

### DIFF
--- a/OpenTK/OpenTK.csproj
+++ b/OpenTK/OpenTK.csproj
@@ -146,7 +146,7 @@
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.Targets" />
   <!-- This actually rewrites the calli and fixed code.-->
   <Target Name="AfterBuild">
-    <Exec Command="$(OutputPath)InteropPatcher.exe $(OutDir)OpenTK.dll" />
+    <Exec Command="mono $(OutputPath)InteropPatcher.exe $(OutDir)OpenTK.dll" />
     <!--Copy back *.dll from bin/Debug|Release to obj/Debug/Release directory-->
     <Copy SourceFiles="@(MainAssembly)" DestinationFolder="$(IntermediateOutputPath)" SkipUnchangedFiles="true" />
     <!-- Copy back *.pdb from bin/Debug|Release to obj/Debug/Release directory-->


### PR DESCRIPTION
To be clear, this pull request _does not_ solve this issue, it just shows how to fix it on non-Windows platforms (i.e.: platforms that use `mono`), I would like feedback on how I can make this work on both platforms