### PR TITLE
Make out binary executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,11 @@ bld/
 [sS]rc/texturecache
 [sS]rc/logs
 [sS]rc/options.txt
+[sS]rc/ClassiCube
 [sS]rc/screenshots
+
+#GCC object files
+*.o
 
 # Roslyn cache directories
 *.ide/
@@ -138,7 +142,7 @@ publish/
 # Publish Web Output
 *.[Pp]ublish.xml
 *.azurePubxml
-# TODO: Comment the next line if you want to checkin your web deploy settings 
+# TODO: Comment the next line if you want to checkin your web deploy settings
 # but database connection strings (with potential passwords) will be unencrypted
 *.pubxml
 *.publishproj

--- a/src/Core.h
+++ b/src/Core.h
@@ -76,6 +76,10 @@ typedef struct Bitmap_ { uint8_t* Scan0; int Width, Height; } Bitmap;
 #endif
 #endif
 
+#ifndef CC_COMMIT_SHA
+#define CC_COMMIT_SHA "Unknown"
+#endif
+
 #ifdef CC_BUILD_D3D9
 typedef void* GfxResourceID;
 #define GFX_NULL NULL

--- a/src/Core.h
+++ b/src/Core.h
@@ -76,10 +76,6 @@ typedef struct Bitmap_ { uint8_t* Scan0; int Width, Height; } Bitmap;
 #endif
 #endif
 
-#ifndef CC_COMMIT_SHA
-#define CC_COMMIT_SHA "Unknown"
-#endif
-
 #ifdef CC_BUILD_D3D9
 typedef void* GfxResourceID;
 #define GFX_NULL NULL

--- a/src/ErrorHandler.c
+++ b/src/ErrorHandler.c
@@ -641,7 +641,10 @@ static void ErrorHandler_FailCommon(ReturnCode result, const char* raw_msg, void
 	String msg = String_NT_Array(msgBuffer);
 
 	String_Format3(&msg, "ClassiCube crashed.%cMessage: %c%c", Platform_NewLine, raw_msg, Platform_NewLine);
+
+	#ifdef CC_COMMIT_SHA
 	String_Format2(&msg, "Commit SHA: %c%c", CC_COMMIT_SHA, Platform_NewLine);
+	#endif
 
 	if (result) {
 		String_Format2(&msg, "%h%c", &result, Platform_NewLine);

--- a/src/ErrorHandler.c
+++ b/src/ErrorHandler.c
@@ -27,7 +27,7 @@ static int ErrorHandler_GetFrames(CONTEXT* ctx, struct StackPointers* pointers, 
 	STACKFRAME frame = { 0 };
 	frame.AddrPC.Mode     = AddrModeFlat;
 	frame.AddrFrame.Mode  = AddrModeFlat;
-	frame.AddrStack.Mode  = AddrModeFlat;	
+	frame.AddrStack.Mode  = AddrModeFlat;
 	DWORD type;
 
 #ifdef _M_IX86
@@ -56,7 +56,7 @@ static int ErrorHandler_GetFrames(CONTEXT* ctx, struct StackPointers* pointers, 
 	int count;
 	CONTEXT copy = *ctx;
 
-	for (count = 0; count < max; count++) {		
+	for (count = 0; count < max; count++) {
 		if (!StackWalk(type, process, thread, &frame, &copy, NULL, SymFunctionTableAccess, SymGetModuleBase, NULL)) break;
 		if (!frame.AddrFrame.Offset) break;
 
@@ -140,7 +140,7 @@ static void ErrorHandler_DumpRegisters(CONTEXT* ctx) {
 	String str = String_FromArray(strBuffer);
 	String_AppendConst(&str, "-- registers --\r\n");
 
-#ifdef _M_IX86	
+#ifdef _M_IX86
 	String_Format3(&str, "eax=%x ebx=%x ecx=%x\r\n", &ctx->Eax, &ctx->Ebx, &ctx->Ecx);
 	String_Format3(&str, "edx=%x esi=%x edi=%x\r\n", &ctx->Edx, &ctx->Esi, &ctx->Edi);
 	String_Format3(&str, "eip=%x ebp=%x esp=%x\r\n", &ctx->Eip, &ctx->Ebp, &ctx->Esp);
@@ -210,12 +210,12 @@ void ErrorHandler_Fail2(ReturnCode result, const char* raw_msg) {
 	/* [ebp] is previous frame's EBP */
 	/* [ebp+4] is previous frame's EIP (return address) */
 	/* address of [ebp+8] is previous frame's ESP */
-	__asm {		
+	__asm {
 		mov eax, [ebp]
-		mov [ctx.Ebp], eax	
+		mov [ctx.Ebp], eax
 		mov eax, [ebp+4]
-		mov [ctx.Eip], eax	
-		lea eax, [ebp+8]	
+		mov [ctx.Eip], eax
+		lea eax, [ebp+8]
 		mov [ctx.Esp], eax
 		mov [ctx.ContextFlags], CONTEXT_CONTROL
 	}
@@ -641,8 +641,10 @@ static void ErrorHandler_FailCommon(ReturnCode result, const char* raw_msg, void
 	String msg = String_NT_Array(msgBuffer);
 
 	String_Format3(&msg, "ClassiCube crashed.%cMessage: %c%c", Platform_NewLine, raw_msg, Platform_NewLine);
-	if (result) { 
-		String_Format2(&msg, "%h%c", &result, Platform_NewLine); 
+	String_Format2(&msg, "Commit SHA: %c%c", CC_COMMIT_SHA, Platform_NewLine);
+
+	if (result) {
+		String_Format2(&msg, "%h%c", &result, Platform_NewLine);
 	} else { result = 1; }
 
 	ErrorHandler_Log(&msg);

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,6 +3,7 @@ LIBS=-lGL -lcurl -lopenal -lpthread -lX11 -lm
 CFLAGS=-g -w -no-pie
 SOURCES=$(wildcard *.c)
 OBJECTS=$(patsubst %.c, %.o, $(SOURCES))
+COMMITSHA=$(shell git rev-parse HEAD | cut -c '1-7')
 
 EXECUTABLE=ClassiCube
 
@@ -10,7 +11,7 @@ $(EXECUTABLE): $(OBJECTS)
 	$(CC) $(CFLAGS) -o $@ $(OBJECTS) $(LIBS)
 
 $(OBJECTS): %.o : %.c
-	$(CC) $(CFLAGS) -c $< $(LIBS) -o $@
+	$(CC) $(CFLAGS) -DCC_COMMIT_SHA=\"$(COMMITSHA)\" -c $< $(LIBS) -o $@
 
 clean:
 	rm -f $(EXECUTABLE) $(OBJECTS)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 CC=gcc
 LIBS=-lGL -lcurl -lopenal -lpthread -lX11 -lm
-CFLAGS=-g -w
+CFLAGS=-g -w -no-pie
 SOURCES=$(wildcard *.c)
 OBJECTS=$(patsubst %.c, %.o, $(SOURCES))
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 CC=gcc
 LIBS=-lGL -lcurl -lopenal -lpthread -lX11 -lm
-CFLAGS=-g -w -no-pie
+CFLAGS=-g -w -no-pie -rdynamic
 SOURCES=$(wildcard *.c)
 OBJECTS=$(patsubst %.c, %.o, $(SOURCES))
 COMMITSHA=$(shell git rev-parse HEAD | cut -c '1-7')

--- a/src/Program.c
+++ b/src/Program.c
@@ -71,7 +71,7 @@ int main(int argc, char** argv) {
 	String_Format1(&defPath, "texpacks%rdefault.zip", &Directory_Separator);
 
 	if (!File_Exists(&defPath)) {
-		ErrorHandler_ShowDialog("Missing file", 
+		ErrorHandler_ShowDialog("Missing file",
 			"default.zip is missing, try running launcher first.\n\nThe game will still run, but without any textures");
 	}
 
@@ -88,12 +88,12 @@ int main(int argc, char** argv) {
 		String_Copy(&Game_Username,  &args[0]);
 		String_Copy(&Game_Mppass,    &args[1]);
 		String_Copy(&Game_IPAddress, &args[2]);
-	
-		if (!Utils_ParseIP(&args[2], ip)) { 
+
+		if (!Utils_ParseIP(&args[2], ip)) {
 			ErrorHandler_ShowDialog("Failed to start", "Invalid IP");
-			Platform_Exit(1); return 1; 
+			Platform_Exit(1); return 1;
 		}
-		if (!Convert_TryParseUInt16(&args[3], &port)) { 
+		if (!Convert_TryParseUInt16(&args[3], &port)) {
 			ErrorHandler_ShowDialog("Failed to start", "Invalid port");
 			Platform_Exit(1); return 1;
 		}


### PR DESCRIPTION
PIE must be disabled to compile the executable file, instead of the shared object.